### PR TITLE
Add ZPL Template functionality.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,15 @@ A zebra label printer driver plugin compatible with the [InvenTree](https://inve
 Goto "Admin Center > Plugins > Install Plugin" and enter `inventree-zebra` as package name and activate it.
 
 Then goto "Admin Center > Machines" and create a new machine using this driver.
+
+
+## ZPL Labels
+You can write a ZPL template and upload
+it to the InvenTree Label templates as usual. Add a command to the template's metadata:
+
+```
+{"zpl_template": "True"}
+```
+
+This causes the printer driver to ignores the picture rendered by WeasyPrint. Instead it calls the `render_to_string` function of the template and sends the
+result to the printer.

--- a/inventree_zebra/core.py
+++ b/inventree_zebra/core.py
@@ -201,14 +201,25 @@ class ZebraLabelPrintingDriver(LabelPrinterBaseDriver):
         printer_init = cast(str, machine.get_setting("PRINTER_INIT", "D"))
         width, height = round(label.width), round(label.height)
 
+        try:
+            zpl_template = label.metadata['zpl_template']
+        except Exception:
+            zpl_template = False
+
+
         for item in items:
-            png = self.render_to_png(label, item, dpi=dpi)
-            if png is None:
-                continue
-            data = png.convert("L").point(
-                lambda x: 255 if x > threshold else 0,  # type: ignore
-                mode="1",
-            )
+
+
+            if zpl_template:
+                data = kwargs['context']['template'].render_as_string(kwargs['item_instance'], None).replace('\n', '')
+            else:
+                png = self.render_to_png(label, item, dpi=dpi)
+                if png is None:
+                    continue
+                data = png.convert("L").point(
+                    lambda x: 255 if x > threshold else 0,  # type: ignore
+                    mode="1",
+                )
 
             lb = zpl.Label(height=height, width=width, dpmm=dpmm)
             lb.set_darkness(darkness)
@@ -216,7 +227,10 @@ class ZebraLabelPrintingDriver(LabelPrinterBaseDriver):
             lb.zpl_raw(printer_init)
             lb.origin(0, 0)
             lb.zpl_raw("^PQ" + str(printing_options.get("copies", 1)))
-            lb.write_graphic(data, width)
+            if zpl_template:
+                lb.zpl_raw(data)
+            else:
+                lb.write_graphic(data, width)
             lb.endorigin()
 
             printer.send_job(lb.dumpZPL())

--- a/inventree_zebra/core.py
+++ b/inventree_zebra/core.py
@@ -211,7 +211,7 @@ class ZebraLabelPrintingDriver(LabelPrinterBaseDriver):
 
 
             if zpl_template:
-                data = kwargs['context']['template'].render_as_string(kwargs['item_instance'], None).replace('\n', '')
+                data = label.render_as_string(item, None).replace('\n', '')
             else:
                 png = self.render_to_png(label, item, dpi=dpi)
                 if png is None:


### PR DESCRIPTION
This allows the use of a `{"zpl_template": "True"}` tag in the label metadata that will send the template output as a string of raw ZPL to the printer instead of rendering it as a PDF.